### PR TITLE
Unify mapAsyncPartitioned implementations

### DIFF
--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/mapAsyncPartitioned.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/mapAsyncPartitioned.md
@@ -9,9 +9,11 @@ The resulting Source or Flow will have elements that retain the order of the ori
 
 ## Signature
 
-@apidoc[Source.mapAsyncPartitioned](Source) { scala="#mapAsyncPartitioned[T,P](parallelism:Int,bufferSize:Int)(partitioner:Out=%3EP)(f:(Out,P)=%3Escala.concurrent.Future[T]):FlowOps.this.Repr[T]" java="#mapAsyncPartitioned(int,int,org.apache.pekko.japi.function.Function,org.apache.pekko.japi.function.Function2" }
-@apidoc[Flow.mapAsyncPartitioned](Source) { scala="#mapAsyncPartitioned[T,P](parallelism:Int,bufferSize:Int)(partitioner:Out=%3EP)(f:(Out,P)=%3Escala.concurrent.Future[T]):FlowOps.this.Repr[T]" java="#mapAsyncPartitioned(int,int,org.apache.pekko.japi.function.Function,org.apache.pekko.japi.function.Function2" }
+@apidoc[Source.mapAsyncPartitioned](Source) { scala="#mapAsyncPartitioned[T,P](parallelism:Int)(partitioner:Out=%3EP)(f:(Out,P)=%3Escala.concurrent.Future[T]):FlowOps.this.Repr[T]" java="#mapAsyncPartitioned(int,org.apache.pekko.japi.function.Function,org.apache.pekko.japi.function.Function2" }
+@apidoc[Flow.mapAsyncPartitioned](Source) { scala="#mapAsyncPartitioned[T,P](parallelism:Int)(partitioner:Out=%3EP)(f:(Out,P)=%3Escala.concurrent.Future[T]):FlowOps.this.Repr[T]" java="#mapAsyncPartitioned(int,org.apache.pekko.japi.function.Function,org.apache.pekko.japi.function.Function2" }
 
 ## Description
 
 Like `mapAsync` but an intermediate partitioning stage is used.
+Up to `parallelism` elements can be processed concurrently, but regardless of their completion time the incoming
+order will be kept when results complete. For use cases where order does not matter `mapAsyncPartitionedUnordered` can be used.

--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/mapAsyncPartitionedUnordered.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/mapAsyncPartitionedUnordered.md
@@ -9,9 +9,12 @@ The resulting Source or Flow will not have ordered elements.
 
 ## Signature
 
-@apidoc[Source.mapAsyncPartitionedUnordered](Source) { scala="#mapAsyncPartitioned[T,P](parallelism:Int,bufferSize:Int)(partitioner:Out=%3EP)(f:(Out,P)=%3Escala.concurrent.Future[T]):FlowOps.this.Repr[T]" java="#mapAsyncPartitioned(int,int,org.apache.pekko.japi.function.Function,org.apache.pekko.japi.function.Function2" }
-@apidoc[Flow.mapAsyncPartitionedUnordered](Source) { scala="#mapAsyncPartitioned[T,P](parallelism:Int,bufferSize:Int)(partitioner:Out=%3EP)(f:(Out,P)=%3Escala.concurrent.Future[T]):FlowOps.this.Repr[T]" java="#mapAsyncPartitioned(int,int,org.apache.pekko.japi.function.Function,org.apache.pekko.japi.function.Function2" }
+@apidoc[Source.mapAsyncPartitionedUnordered](Source) { scala="#mapAsyncPartitioned[T,P](parallelism:Int)(partitioner:Out=%3EP)(f:(Out,P)=%3Escala.concurrent.Future[T]):FlowOps.this.Repr[T]" java="#mapAsyncPartitioned(int,org.apache.pekko.japi.function.Function,org.apache.pekko.japi.function.Function2" }
+@apidoc[Flow.mapAsyncPartitionedUnordered](Source) { scala="#mapAsyncPartitioned[T,P](parallelism:Int)(partitioner:Out=%3EP)(f:(Out,P)=%3Escala.concurrent.Future[T]):FlowOps.this.Repr[T]" java="#mapAsyncPartitioned(int,org.apache.pekko.japi.function.Function,org.apache.pekko.japi.function.Function2" }
 
 ## Description
 
 Like `mapAsync` but an intermediate partitioning stage is used.
+Up to `parallelism` elements can be processed concurrently for a partition and pushed down the stream regardless of the
+order of the partitions that triggered them. In other words, the order of the output elements will be preserved only within a partition.
+For use cases where order does matter `mapAsyncPartitioned` can be used.

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -839,19 +839,17 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * @since 1.1.0
    */
   def mapAsyncPartitioned[T, P](parallelism: Int,
-      bufferSize: Int,
       extractPartition: function.Function[Out, P],
       f: function.Function2[Out, P, CompletionStage[T]]): Flow[In, T, Mat] =
-    MapAsyncPartitioned.mapFlowOrdered(delegate, parallelism, bufferSize)(extractPartition(_))(f(_, _).asScala).asJava
+    MapAsyncPartitioned.mapFlowOrdered(delegate, parallelism)(extractPartition(_))(f(_, _).asScala).asJava
 
   /**
    * @since 1.1.0
    */
   def mapAsyncPartitionedUnordered[T, P](parallelism: Int,
-      bufferSize: Int,
       extractPartition: function.Function[Out, P],
       f: function.Function2[Out, P, CompletionStage[T]]): Flow[In, T, Mat] =
-    MapAsyncPartitioned.mapFlowUnordered(delegate, parallelism, bufferSize)(extractPartition(_))(f(_, _).asScala).asJava
+    MapAsyncPartitioned.mapFlowUnordered(delegate, parallelism)(extractPartition(_))(f(_, _).asScala).asJava
 
   /**
    * Transform this stream by applying the given function to each of the elements

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/FlowWithContext.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/FlowWithContext.scala
@@ -182,20 +182,18 @@ final class FlowWithContext[In, CtxIn, Out, CtxOut, +Mat](
    * @since 1.1.0
    */
   def mapAsyncPartitioned[Out2, P](parallelism: Int,
-      bufferSize: Int,
       extractPartition: function.Function[Out, P],
       f: function.Function2[Out, P, CompletionStage[Out2]]): FlowWithContext[In, CtxIn, Out2, CtxOut, Mat] = {
-    viaScala(_.mapAsyncPartitioned(parallelism, bufferSize)(extractPartition(_))(f(_, _).asScala))
+    viaScala(_.mapAsyncPartitioned(parallelism)(extractPartition(_))(f(_, _).asScala))
   }
 
   /**
    * @since 1.1.0
    */
   def mapAsyncPartitionedUnordered[Out2, P](parallelism: Int,
-      bufferSize: Int,
       extractPartition: function.Function[Out, P],
       f: function.Function2[Out, P, CompletionStage[Out2]]): FlowWithContext[In, CtxIn, Out2, CtxOut, Mat] = {
-    viaScala(_.mapAsyncPartitionedUnordered(parallelism, bufferSize)(extractPartition(_))(f(_, _).asScala))
+    viaScala(_.mapAsyncPartitionedUnordered(parallelism)(extractPartition(_))(f(_, _).asScala))
   }
 
   /**

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -2493,20 +2493,18 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * @since 1.1.0
    */
   def mapAsyncPartitioned[T, P](parallelism: Int,
-      bufferSize: Int,
       extractPartition: function.Function[Out, P],
       f: function.Function2[Out, P, CompletionStage[T]]): javadsl.Source[T, Mat] =
-    MapAsyncPartitioned.mapSourceOrdered(delegate, parallelism, bufferSize)(extractPartition(_))(f(_,
+    MapAsyncPartitioned.mapSourceOrdered(delegate, parallelism)(extractPartition(_))(f(_,
       _).asScala).asJava
 
   /**
    * @since 1.1.0
    */
   def mapAsyncPartitionedUnordered[T, P](parallelism: Int,
-      bufferSize: Int,
       extractPartition: function.Function[Out, P],
       f: function.Function2[Out, P, CompletionStage[T]]): javadsl.Source[T, Mat] =
-    MapAsyncPartitioned.mapSourceUnordered(delegate, parallelism, bufferSize)(extractPartition(_))(f(_,
+    MapAsyncPartitioned.mapSourceUnordered(delegate, parallelism)(extractPartition(_))(f(_,
       _).asScala).asJava
 
   /**

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SourceWithContext.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SourceWithContext.scala
@@ -178,10 +178,9 @@ final class SourceWithContext[+Out, +Ctx, +Mat](delegate: scaladsl.SourceWithCon
    * @since 1.1.0
    */
   def mapAsyncPartitioned[Out2, P](parallelism: Int,
-      bufferSize: Int,
       extractPartition: function.Function[Out, P],
       f: function.Function2[Out, P, CompletionStage[Out2]]): SourceWithContext[Out2, Ctx, Mat] = {
-    MapAsyncPartitioned.mapSourceWithContextOrdered(delegate, parallelism, bufferSize)(extractPartition(_))(f(_,
+    MapAsyncPartitioned.mapSourceWithContextOrdered(delegate, parallelism)(extractPartition(_))(f(_,
       _).asScala)
       .asJava
   }
@@ -190,10 +189,9 @@ final class SourceWithContext[+Out, +Ctx, +Mat](delegate: scaladsl.SourceWithCon
    * @since 1.1.0
    */
   def mapAsyncPartitionedUnordered[Out2, P](parallelism: Int,
-      bufferSize: Int,
       extractPartition: function.Function[Out, P],
       f: function.Function2[Out, P, CompletionStage[Out2]]): SourceWithContext[Out2, Ctx, Mat] = {
-    MapAsyncPartitioned.mapSourceWithContextUnordered(delegate, parallelism, bufferSize)(extractPartition(_))(f(_,
+    MapAsyncPartitioned.mapSourceWithContextUnordered(delegate, parallelism)(extractPartition(_))(f(_,
       _).asScala)
       .asJava
   }

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -166,21 +166,19 @@ final class Flow[-In, +Out, +Mat](
   /**
    * @since 1.1.0
    */
-  def mapAsyncPartitioned[T, P](parallelism: Int,
-      bufferSize: Int = MapAsyncPartitioned.DefaultBufferSize)(
+  def mapAsyncPartitioned[T, P](parallelism: Int)(
       extractPartition: Out => P)(
       f: (Out, P) => Future[T]): Flow[In, T, Mat] = {
-    MapAsyncPartitioned.mapFlowOrdered(this, parallelism, bufferSize)(extractPartition)(f)
+    MapAsyncPartitioned.mapFlowOrdered(this, parallelism)(extractPartition)(f)
   }
 
   /**
    * @since 1.1.0
    */
-  def mapAsyncPartitionedUnordered[T, P](parallelism: Int,
-      bufferSize: Int = MapAsyncPartitioned.DefaultBufferSize)(
+  def mapAsyncPartitionedUnordered[T, P](parallelism: Int)(
       extractPartition: Out => P)(
       f: (Out, P) => Future[T]): Flow[In, T, Mat] = {
-    MapAsyncPartitioned.mapFlowUnordered(this, parallelism, bufferSize)(extractPartition)(f)
+    MapAsyncPartitioned.mapFlowUnordered(this, parallelism)(extractPartition)(f)
   }
 
   /**

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/FlowWithContext.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/FlowWithContext.scala
@@ -93,21 +93,19 @@ final class FlowWithContext[-In, -CtxIn, +Out, +CtxOut, +Mat](delegate: Flow[(In
   /**
    * @since 1.1.0
    */
-  def mapAsyncPartitioned[T, P](parallelism: Int,
-      bufferSize: Int = MapAsyncPartitioned.DefaultBufferSize)(
+  def mapAsyncPartitioned[T, P](parallelism: Int)(
       extractPartition: Out => P)(
       f: (Out, P) => Future[T]): FlowWithContext[In, CtxIn, T, CtxOut, Mat] = {
-    MapAsyncPartitioned.mapFlowWithContextOrdered(this, parallelism, bufferSize)(extractPartition)(f)
+    MapAsyncPartitioned.mapFlowWithContextOrdered(this, parallelism)(extractPartition)(f)
   }
 
   /**
    * @since 1.1.0
    */
-  def mapAsyncPartitionedUnordered[T, P](parallelism: Int,
-      bufferSize: Int = MapAsyncPartitioned.DefaultBufferSize)(
+  def mapAsyncPartitionedUnordered[T, P](parallelism: Int)(
       extractPartition: Out => P)(
       f: (Out, P) => Future[T]): FlowWithContext[In, CtxIn, T, CtxOut, Mat] = {
-    MapAsyncPartitioned.mapFlowWithContextUnordered(this, parallelism, bufferSize)(extractPartition)(f)
+    MapAsyncPartitioned.mapFlowWithContextUnordered(this, parallelism)(extractPartition)(f)
   }
 
   def asFlow: Flow[(In, CtxIn), (Out, CtxOut), Mat] = delegate

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Source.scala
@@ -102,17 +102,17 @@ final class Source[+Out, +Mat](
   /**
    * @since 1.1.0
    */
-  def mapAsyncPartitioned[T, P](parallelism: Int, bufferSize: Int = MapAsyncPartitioned.DefaultBufferSize)(
+  def mapAsyncPartitioned[T, P](parallelism: Int)(
       extractPartition: Out => P)(f: (Out, P) => Future[T]): Source[T, Mat] = {
-    MapAsyncPartitioned.mapSourceOrdered(this, parallelism, bufferSize)(extractPartition)(f)
+    MapAsyncPartitioned.mapSourceOrdered(this, parallelism)(extractPartition)(f)
   }
 
   /**
    * @since 1.1.0
    */
-  def mapAsyncPartitionedUnordered[T, P](parallelism: Int, bufferSize: Int = MapAsyncPartitioned.DefaultBufferSize)(
+  def mapAsyncPartitionedUnordered[T, P](parallelism: Int)(
       extractPartition: Out => P)(f: (Out, P) => Future[T]): Source[T, Mat] = {
-    MapAsyncPartitioned.mapSourceUnordered(this, parallelism, bufferSize)(extractPartition)(f)
+    MapAsyncPartitioned.mapSourceUnordered(this, parallelism)(extractPartition)(f)
   }
 
   /**

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/SourceWithContext.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/SourceWithContext.scala
@@ -81,17 +81,17 @@ final class SourceWithContext[+Out, +Ctx, +Mat] private[stream] (delegate: Sourc
   /**
    * @since 1.1.0
    */
-  def mapAsyncPartitioned[T, P](parallelism: Int, bufferSize: Int = MapAsyncPartitioned.DefaultBufferSize)(
+  def mapAsyncPartitioned[T, P](parallelism: Int)(
       extractPartition: Out => P)(f: (Out, P) => Future[T]): SourceWithContext[T, Ctx, Mat] = {
-    MapAsyncPartitioned.mapSourceWithContextOrdered(this, parallelism, bufferSize)(extractPartition)(f)
+    MapAsyncPartitioned.mapSourceWithContextOrdered(this, parallelism)(extractPartition)(f)
   }
 
   /**
    * @since 1.1.0
    */
-  def mapAsyncPartitionedUnordered[T, P](parallelism: Int, bufferSize: Int = MapAsyncPartitioned.DefaultBufferSize)(
+  def mapAsyncPartitionedUnordered[T, P](parallelism: Int)(
       extractPartition: Out => P)(f: (Out, P) => Future[T]): SourceWithContext[T, Ctx, Mat] = {
-    MapAsyncPartitioned.mapSourceWithContextUnordered(this, parallelism, bufferSize)(extractPartition)(f)
+    MapAsyncPartitioned.mapSourceWithContextUnordered(this, parallelism)(extractPartition)(f)
   }
 
   /**


### PR DESCRIPTION
1. Unified both of the implementations (now they differ only by the way elements are pushed down the stream)
2. Removed bufferSize parameter
3. Added a check for the parallelism parameter